### PR TITLE
Force the use of the lockfile during CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 - cp src/server/config.user.example.js src/server/config.user.js
 - cp src/client/config.user.example.js src/client/config.user.js
 install:
-- yarn
+- yarn --frozen-lockfile --non-interactive
 - yarn run build
 before_script:
 - nohup yarn start &

--- a/yarn.lock
+++ b/yarn.lock
@@ -4644,7 +4644,7 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three@^0.102.1:
+three@~0.102.1:
   version "0.102.1"
   resolved "https://registry.yarnpkg.com/three/-/three-0.102.1.tgz#fc08b6b11860cf59e8cd45b7e90e34d1d1a8cbd6"
   integrity sha512-btHBdww/Es4vdBkB2GjTE9mpj0vy8tgtxkX7ne7uxySXV8zoGxWJv1N88BydxnCqvAfmD4ZUTqPeESO7oDgeOQ==


### PR DESCRIPTION
I promise I also updated the deployment script to use the lockfile. <3

From now on, whenever the package.json is modified, you should also generate and commit the new yarn.lock file that goes with it.

Closes #114 