### PR TITLE
Editor transform fixes and changes

### DIFF
--- a/src/client/editor/inspector.js
+++ b/src/client/editor/inspector.js
@@ -136,25 +136,33 @@ let inspector = function() {
 
 			// Translation
 			transformFunctions.translate = function(axis, value) {
+				if(isNaN(value)) value = 0;
 				let position = inspector.selected.getPosition();
-				position[axis] = parseFloat(value);
+				position[axis] = value;
 				inspector.selected.setPosition(position);
 			};
 
 			// Scale
 			transformFunctions.scale = function(axis, value) {
+				if(isNaN(value)) value = 1;
 				let scale = inspector.selected.getScale();
-				scale[axis] = parseFloat(value);
+				scale[axis] = value;
 				inspector.selected.setScale(scale);
 			};
 
 			// Rotate
 			transformFunctions.rotate = function() {
 				let rotation = inspector.elements.transform.input.rotate;
+				let x = rotation.x.valueAsNumber;
+				if(isNaN(x)) x = 0;
+				let y = rotation.y.valueAsNumber;
+				if(isNaN(y)) y = 0;
+				let z = rotation.z.valueAsNumber;
+				if(isNaN(z)) z = 0;
 				inspector.selected.setRotation(new THREE.Euler(
-					parseFloat(rotation.x.value) * Math.PI / 180,
-					parseFloat(rotation.y.value) * Math.PI / 180,
-					parseFloat(rotation.z.value) * Math.PI / 180,
+					x * Math.PI / 180,
+					y * Math.PI / 180,
+					z * Math.PI / 180,
 					"XYZ"));
 			};
 
@@ -166,8 +174,8 @@ let inspector = function() {
 				for (let key in transformElements.input[transform]) {
 					let el = transformElements.input[transform][key];
 					let func = transformFunctions[transform];
-					el.addEventListener("change", function() { func(this.dataset.axis, this.value); }, false);
-					el.addEventListener("input", function() { func(this.dataset.axis, this.value); }, false);
+					el.addEventListener("change", function() { func(this.dataset.axis, this.valueAsNumber); }, false);
+					el.addEventListener("input", function() { func(this.dataset.axis, this.valueAsNumber); }, false);
 				}
 			}
 			// Label
@@ -196,22 +204,30 @@ let inspector = function() {
 
 			// Width
 			shapeChangeFunctions.width = function() {
-				inspector.selected.setWidth(parseFloat(inspector.elements.shapeProperties.input.width.value));
+				let value = inspector.elements.shapeProperties.input.width.valueAsNumber;
+				if(isNaN(value)) value = 1;
+				inspector.selected.setWidth(value);
 			};
 
 			// Height
 			shapeChangeFunctions.height = function() {
-				inspector.selected.setHeight(parseFloat(inspector.elements.shapeProperties.input.height.value));
+				let value = inspector.elements.shapeProperties.input.height.valueAsNumber;
+				if(isNaN(value)) value = 1;
+				inspector.selected.setHeight(value);
 			};
 
 			// Depth
 			shapeChangeFunctions.depth = function() {
-				inspector.selected.setDepth(parseFloat(inspector.elements.shapeProperties.input.depth.value));
+				let value = inspector.elements.shapeProperties.input.depth.valueAsNumber;
+				if(isNaN(value)) value = 1;
+				inspector.selected.setDepth(value);
 			};
 
 			// Radius
 			shapeChangeFunctions.radius = function() {
-				inspector.selected.setRadius(parseFloat(inspector.elements.shapeProperties.input.radius.value));
+				let value = inspector.elements.shapeProperties.input.radius.valueAsNumber;
+				if(isNaN(value)) value = 1;
+				inspector.selected.setRadius(value);
 			};
 
 			// Input

--- a/src/client/editor/inspector.js
+++ b/src/client/editor/inspector.js
@@ -163,7 +163,7 @@ let inspector = function() {
 					x * Math.PI / 180,
 					y * Math.PI / 180,
 					z * Math.PI / 180,
-					"XYZ"));
+					"YXZ"));
 			};
 
 			// Attach event listeners to inputs and labels

--- a/src/client/editor/inspector.js
+++ b/src/client/editor/inspector.js
@@ -101,9 +101,11 @@ let inspector = function() {
 					inspector.selected.setFunctionality(this.value);
 
 					if(this.value === "startarea") {
-						inspector.elements.shape.value = "box";
 						inspector.elements.shape.disabled = true;
-						inspectorChangeShape();
+						if(inspector.selected.colliderData.shape !== "box") {
+							inspector.elements.shape.value = "box";
+							inspectorChangeShape();
+						}
 					} else {
 						inspector.elements.shape.disabled = false;
 					}

--- a/src/client/editor/models.js
+++ b/src/client/editor/models.js
@@ -8,6 +8,7 @@ import { scene } from "./render";
 function Model(name, sceneObject) {
 	this.name = name;
 	this.sceneObject = sceneObject;
+	this.sceneObject.rotation.order = "YXZ";
 	this.element = null;
 	this.prefabEntities = {};
 

--- a/src/client/editor/prefabs.js
+++ b/src/client/editor/prefabs.js
@@ -291,6 +291,7 @@ function PrefabObject(uuid, parent) {
 	PrefabEntity.call(this, "object", uuid, parent);
 	this.model = "null"; // Note: HAS to be a string for inspector purposes!
 	this.sceneObject = defaultModel.clone();
+	this.sceneObject.rotation.order = "YXZ";
 	this.updateTransformFromProject();
 	this.parent.group.add(this.sceneObject);
 
@@ -317,10 +318,6 @@ PrefabObject.prototype.setModel = function(modelName) {
 		delete modelsTab.models[this.model].prefabEntities[this.uuid];
 	}
 
-	let position = this.sceneObject.position;
-	let rotation = this.sceneObject.rotation;
-	let scale = this.sceneObject.scale;
-
 	let model = null;
 
 	// For null or non-existing models, use default
@@ -342,6 +339,10 @@ PrefabObject.prototype.setModel = function(modelName) {
 		this.project.model = null;
 		model = defaultModel;
 	}
+
+	let position = this.sceneObject.position;
+	let rotation = this.sceneObject.rotation;
+	let scale = this.sceneObject.scale;
 
 	// Set new model
 	this.sceneObject = model.clone();
@@ -365,6 +366,7 @@ function PrefabCollider(uuid, parent) {
 	};
 	let geometry = new THREE.BoxBufferGeometry( 1, 1, 1 );
 	this.sceneObject = new THREE.Mesh(geometry, materials.physicsMaterial );
+	this.sceneObject.rotation.order = "YXZ";
 	this.updateTransformFromProject();
 	if(this.project.scale) delete this.project.scale;
 	this.parent.group.add(this.sceneObject);

--- a/src/client/editor/world.js
+++ b/src/client/editor/world.js
@@ -40,6 +40,7 @@ function WorldObject(uuid, prefab, project) {
 
 	// Add threejs group to scene
 	this.sceneObject = prefab.group.clone();
+	this.sceneObject.rotation.order = "YXZ";
 	this.updateTransformFromProject();
 	worldTab.group.add( this.sceneObject );
 	this.sceneObject.visible = true;

--- a/templates/editor.mustache
+++ b/templates/editor.mustache
@@ -88,25 +88,25 @@
 								<tr class="translate">
 									<td>Position</td>
 									<td>
-										<div><input type="number" value="0" step=".01" disabled data-axis="x" /><span class="x">X</span></div>
-										<div><input type="number" value="0" step=".01" disabled data-axis="y" /><span class="y">Y</span></div>
-										<div><input type="number" value="0" step=".01" disabled data-axis="z" /><span class="z">Z</span></div>
+										<div><input type="number" value="0" step=".01" required disabled data-axis="x" /><span class="x">X</span></div>
+										<div><input type="number" value="0" step=".01" required disabled data-axis="y" /><span class="y">Y</span></div>
+										<div><input type="number" value="0" step=".01" required disabled data-axis="z" /><span class="z">Z</span></div>
 									</td>
 								</tr>
 								<tr class="rotate">
 									<td>Rotation</td>
 									<td>
-										<div><input type="number" value="0" step=".1" disabled data-axis="x" /><span class="x">X</span></div>
-										<div><input type="number" value="0" step=".1" disabled data-axis="y" /><span class="y">Y</span></div>
-										<div><input type="number" value="0" step=".1" disabled data-axis="z" /><span class="z">Z</span></div>
+										<div><input type="number" value="0" step=".1" required disabled data-axis="x" /><span class="x">X</span></div>
+										<div><input type="number" value="0" step=".1" required disabled data-axis="y" /><span class="y">Y</span></div>
+										<div><input type="number" value="0" step=".1" required disabled data-axis="z" /><span class="z">Z</span></div>
 									</td>
 								</tr>
 								<tr class="scale objectProperty">
 									<td>Scale</td>
 									<td>
-										<div><input type="number" value="1" step=".01" disabled data-axis="x" /><span class="x">X</span></div>
-										<div><input type="number" value="1" step=".01" disabled data-axis="y" /><span class="y">Y</span></div>
-										<div><input type="number" value="1" step=".01" disabled data-axis="z" /><span class="z">Z</span></div>
+										<div><input type="number" value="1" step=".01" required disabled data-axis="x" /><span class="x">X</span></div>
+										<div><input type="number" value="1" step=".01" required disabled data-axis="y" /><span class="y">Y</span></div>
+										<div><input type="number" value="1" step=".01" required disabled data-axis="z" /><span class="z">Z</span></div>
 									</td>
 								</tr>
 							</tbody>
@@ -154,10 +154,10 @@
 								<tr id="shapeProperties" class="shapeProperties colliderProperty box">
 									<td>Shape properties</td>
 									<td>
-										<div class="sphere cylinder cone capsule"><input type="number" value="1" step=".01" disabled /><span class="q">RADIUS</span></div>
-										<div class="box"><input type="number" value="1" step=".01" disabled /><span class="q">WIDTH</span></div>
-										<div class="box cylinder cone capsule"><input type="number" value="1" step=".01" disabled /><span class="q">HEIGHT</span></div>
-										<div class="box"><input type="number" value="1" step=".01" disabled /><span class="q">DEPTH</span></div>
+										<div class="sphere cylinder cone capsule"><input type="number" value="1" step=".01" required disabled /><span class="q">RADIUS</span></div>
+										<div class="box"><input type="number" value="1" step=".01" required disabled /><span class="q">WIDTH</span></div>
+										<div class="box cylinder cone capsule"><input type="number" value="1" step=".01" required disabled /><span class="q">HEIGHT</span></div>
+										<div class="box"><input type="number" value="1" step=".01" required disabled /><span class="q">DEPTH</span></div>
 										<div class="terrain"><input type="file" id="terPhysics"/></div>
 									</td>
 								</tr>

--- a/templates/editor.mustache
+++ b/templates/editor.mustache
@@ -154,10 +154,10 @@
 								<tr id="shapeProperties" class="shapeProperties colliderProperty box">
 									<td>Shape properties</td>
 									<td>
-										<div class="sphere cylinder cone capsule"><input type="number" value="1" step=".01" required disabled /><span class="q">RADIUS</span></div>
-										<div class="box"><input type="number" value="1" step=".01" required disabled /><span class="q">WIDTH</span></div>
-										<div class="box cylinder cone capsule"><input type="number" value="1" step=".01" required disabled /><span class="q">HEIGHT</span></div>
-										<div class="box"><input type="number" value="1" step=".01" required disabled /><span class="q">DEPTH</span></div>
+										<div class="sphere cylinder cone capsule"><input type="number" value="1" step=".01" min=".01" required disabled /><span class="q">RADIUS</span></div>
+										<div class="box"><input type="number" value="1" step=".01" min=".01" required disabled /><span class="q">WIDTH</span></div>
+										<div class="box cylinder cone capsule"><input type="number" value="1" step=".01" min=".01" required disabled /><span class="q">HEIGHT</span></div>
+										<div class="box"><input type="number" value="1" step=".01" min=".01" required disabled /><span class="q">DEPTH</span></div>
 										<div class="terrain"><input type="file" id="terPhysics"/></div>
 									</td>
 								</tr>


### PR DESCRIPTION
No Issues to reference since there are none! But there sure were some things worth changing:
- Fixed object position/scale/shape properties being set to NaN, caused by invalid input fields.
- Fixed a bug where box shape properties were reset when changing collider function to Starting Area.
- Changed the Euler rotation order from `XYZ` to `YXZ`, which means the following:
    - Possibly a bit more intuitive for track prefabs: First the direction (Y), and then the slope pitch/roll (XZ) rotations are applied.
    - No gimbal lock when Y is 90°, which feeds into the reasoning above. (It's on X=90° now, which is much less likely.)
    - Level files and loading is unaffected since they're stored in quaternions. The Euler angle values may change when loading it in the editor but the rotations remain the same.