### PR TITLE
Fixed invalid default config example file values

### DIFF
--- a/src/client/config.user.example.js
+++ b/src/client/config.user.example.js
@@ -2,8 +2,8 @@
 // To see which properties you can override, check config.js
 
 const userConfig = {
-	"config.contact.email": "c2VuZEBudWRlcy5tZQ==",
-	"config.contact.decode": function(str) {
+	"contact.email": "c2VuZEBudWRlcy5tZQ==",
+	"contact.decode": function(str) {
 		return atob(str);
 	},
 


### PR DESCRIPTION
Default example configuration still had the `config.` prefix, which it should not have. Thanks @Sanquinary for reporting this issue.