### PR TITLE
Sprite render fix, and some server-side tweaks

### DIFF
--- a/src/client/marble-manager.js
+++ b/src/client/marble-manager.js
@@ -16,6 +16,7 @@ let marbleManager = function() {
 		initialize: function() {
 			this.marbleGroup = new THREE.Group();
 			this.marbleNamesGroup = new THREE.Group();
+			this.marbleNamesGroup.renderOrder = 1;
 			renderCore.mainScene.add(this.marbleGroup);
 			renderCore.mainScene.add(this.marbleNamesGroup);
 

--- a/src/server/game.js
+++ b/src/server/game.js
@@ -10,7 +10,7 @@ function Marble(id, entryId, name, color) {
 	this.useFancy = Math.random() > .99;
 	this.color = color || _randomHexColor();
 	this.name = name || "Nightbot";
-	this.size = (Math.random() > .95 ? (.3 + Math.random() * .7) : false) || 0.2;
+	this.size = (Math.random() > .98 ? (.3 + Math.random() * .3) : false) || 0.2;
 	this.ammoBody = null;
 	this.finished = false;
 	this.rank = null;
@@ -138,8 +138,11 @@ let game = function() {
 
 		// Spawns marble unless the maximum amount of marbles has been hit
 		spawnMarble(id, name, color) {
-			// Check whether we have reached the maximum marble limit
-			if (_marbles.length >= config.marbles.rules.maxMarbleCount) return;
+			if (
+				// Check whether the game state disallows new marbles
+				this.currentGameState === "finished"
+				// Check whether we have reached the maximum marble limit
+				|| _marbles.length >= config.marbles.rules.maxMarbleCount) return;
 
 			let newMarble = new Marble(id, _marbles.length, name, color);
 			_marbles.push(newMarble);


### PR DESCRIPTION
- Fixed cases where name sprites were sometimes rendered before/after water, causing strange effects.
- Lowered big marble frequency from 5% -> 2%, and reduced maximum size somewhat.
- Ensured that marbles can't spawn during the game's `finished` state, since this caused marbles to disappear and/or be synced incorrectly on the client.