### PR TITLE
Marble name highlighted fix

### DIFF
--- a/src/client/marble-manager.js
+++ b/src/client/marble-manager.js
@@ -99,7 +99,7 @@ const MarbleMesh = function(marbleData) {
 
 	// Highlight own name
 	let nameSpriteOptions = {};
-	if (_userData && _userData.username === this.name) {
+	if (_userData && _userData.id === marbleData.userId) {
 		nameSpriteOptions.color = "#BA0069";
 		nameSpriteOptions.renderOrder = 9e9;
 	}


### PR DESCRIPTION
Changed the user check to be based on user ID rather than the name, since nicknames causes this check to fail.