### PR TITLE
Async level loading + few tweaks

### DIFF
--- a/src/client/client/game.js
+++ b/src/client/client/game.js
@@ -3,7 +3,6 @@ import * as Cookies from "js-cookie";
 import { levelManager } from "../level-manager";
 import { marbleManager } from "../marble-manager";
 import { renderCore } from "../render/render-core";
-import * as levelIO from "../../level/level-io";
 
 let _userData = Cookies.getJSON("user_data");
 
@@ -14,6 +13,8 @@ let game = function() {
 		},
 
 		_enteredMarbleList = [],
+
+		_currentLevelId = null,
 
 		_serverData = {
 			currentGameState: null,
@@ -343,20 +344,14 @@ let game = function() {
 
 			// Start loading the level asynchronously
 			let levelName = gameState.levelId;
-			fetch(`/resources/maps/${levelName}.mmc`)
-				.then((response) => {
-					// Return as a buffer, since .text() tries to convert to UTF-8 which is undesirable for compressed data
-					return response.arrayBuffer();
-				})
-				.then((buffer) => {
-					let levelData = levelIO.load(buffer);
-					levelManager.activeLevel.loadLevel(levelData)
-						.then( () => {
-							if(this.getCurrentGameState() === "started") {
-								levelManager.activeLevel.openGates();
-							}
-						});
+			if(_currentLevelId !== levelName) {
+				_currentLevelId = levelName;
+				levelManager.activeLevel.loadLevelFromUrl(`/resources/maps/${levelName}.mmc`).then( () => {
+					if(this.getCurrentGameState() === "started") {
+						levelManager.activeLevel.openGates();
+					}
 				});
+			}
 		}
 	};
 }();

--- a/src/client/client/game.js
+++ b/src/client/client/game.js
@@ -343,10 +343,9 @@ let game = function() {
 			}
 
 			// Start loading the level asynchronously
-			let levelName = gameState.levelId;
-			if(_currentLevelId !== levelName) {
-				_currentLevelId = levelName;
-				levelManager.activeLevel.loadLevelFromUrl(`/resources/maps/${levelName}.mmc`).then( () => {
+			if(_currentLevelId !== gameState.levelId) {
+				_currentLevelId = gameState.levelId;
+				levelManager.activeLevel.loadLevelFromUrl(`/resources/maps/${_currentLevelId}.mmc`).then( () => {
 					if(this.getCurrentGameState() === "started") {
 						levelManager.activeLevel.openGates();
 					}

--- a/src/client/level-loader.worker.js
+++ b/src/client/level-loader.worker.js
@@ -23,7 +23,8 @@ let loadLevelData = function(url) {
 					loadingFinished(true, levelData);
 				}
 			}
-		}).catch( (error) => {
+		})
+		.catch( (error) => {
 			console.log(error);
 			loadingFinished(false, "An unknown error occurred.");
 		});

--- a/src/client/level-loader.worker.js
+++ b/src/client/level-loader.worker.js
@@ -1,0 +1,37 @@
+import * as levelIO from "../level/level-io";
+
+onmessage = function(message) {
+	loadLevelData(message.data.url);
+};
+
+let loadLevelData = function(url) {
+	fetch(`${url}`)
+		.then((response) => {
+			if(response.ok) {
+				return response.arrayBuffer();
+			} else {
+				loadingFinished(false, `Unable to retrieve ${url} from server: ${response.status} - ${response.statusText}`);
+				return false;
+			}
+		})
+		.then((buffer) => {
+			if(buffer) {
+				let levelData = levelIO.load(buffer);
+				if(levelData === null) {
+					loadingFinished(false, "Failed to load level data.");
+				} else {
+					loadingFinished(true, levelData);
+				}
+			}
+		}).catch( (error) => {
+			console.log(error);
+			loadingFinished(false, "An unknown error occurred.");
+		});
+};
+
+function loadingFinished(success, payload) {
+	postMessage({
+		success,
+		payload
+	});
+}


### PR DESCRIPTION
**Changes**
- `MarbleLevel` now loads default level data in the constructor (instead of being manually set before).
- Added a function that uses a worker thread to fetch/parse level data, and loads the level on the main thread afterwards.
- Level data loading has a bit more error checking now.
- `game.js` will keep track of what level is currently loaded, so it won't unnecessarily reload on reconnect.

On my machine, the async loading part takes about 1600ms which is now off the main thread. Pretty neat!

**Referencing issues**
Closes #191
