### PR TITLE
Client reconnect fixes

### DIFF
--- a/src/client/chat/chat.js
+++ b/src/client/chat/chat.js
@@ -132,17 +132,17 @@ domReady.then(() => {
 	});
 
 	// On websocket close (disconnect), add warning message. Reconnecting happens automagically.
-	ws.addEventListener("close", function(event) {
+	ws.addEventListener("close", () => {
 		let clone = chatMessageTemplate.cloneNode(true);
 		clone.removeAttribute("id");
 		clone.getElementsByClassName("timestamp")[0].innerText = timestamp();
 		clone.getElementsByClassName("content")[0].removeChild(clone.getElementsByClassName("username")[0]);
 		clone.getElementsByClassName("content")[0].innerText =
-			`Lost connection... Attempt #${event.target._retryCount} to reconnect in ${
+			`Lost connection... Attempt #${ws._retryCount} to reconnect in ${
 				Math.min(Math.ceil(
-					event.target._options.minReconnectionDelay
-					* event.target._options.reconnectionDelayGrowFactor
-					** (event.target._retryCount - 1)
+					ws._options.minReconnectionDelay
+					* ws._options.reconnectionDelayGrowFactor
+					** (ws._retryCount - 1)
 					/ 1000
 				), 30)
 			} seconds`;

--- a/src/client/client/networking.js
+++ b/src/client/client/networking.js
@@ -102,6 +102,7 @@ let networking = function() {
 			_ws.binaryType = "arraybuffer";
 
 			_ws.addEventListener("open", () => {
+				game.resetGame(); // New session start
 				this.websocketOpen = true;
 			});
 

--- a/src/server/game.js
+++ b/src/server/game.js
@@ -140,7 +140,7 @@ let game = function() {
 		_netGameStatePayload = null;
 
 		// gameState
-		if(_netGameUpdate.g) {
+		if(_netGameUpdate.g !== undefined) {
 			_netGameState.g = _netGameUpdate.g;
 
 			// Remove all marbles if the state changed to finished


### PR DESCRIPTION
- Fixed a TypeError in `chat.js`, which hid the first reconnect message.
- The client's game state resets the moment a connection is (re)made, so the game's cleaned up before initial data is being processed.
- Fixed a dumb that caused the initial data to never have the game's state as "waiting".