### PR TITLE
Fix for #219

### DIFF
--- a/src/client/client/game.js
+++ b/src/client/client/game.js
@@ -42,6 +42,7 @@ let game = function() {
 			let mesh = null;
 			if (_marbleBeingTracked === marble) {
 				_marbleBeingTracked = null;
+				renderCore.setCameraStyle(cameras.CAMERA_FREE);
 				marble.listEntryElement.getElementsByClassName("camera")[0].classList.remove("selected");
 			} else {
 				if (_marbleBeingTracked) {


### PR DESCRIPTION
Goes into free-mode whenever targeted marble is deselected.

Closes #219 
