### PR TITLE
Fixed not being able to log out when deployed remotely

### DIFF
--- a/src/client/chat/chat.js
+++ b/src/client/chat/chat.js
@@ -65,7 +65,12 @@ domReady.then(() => {
 					response.tokenBody.discriminator = cookieData.discriminator;
 					response.tokenBody.avatar = cookieData.avatar;
 					let days = (response.tokenBody.expires_in / 62400) - 0.1; // seconds to days minus some slack
-					Cookies.set("user_data", response.tokenBody, { expires: days });
+					Cookies.set("user_data", response.tokenBody, {
+						expires: days,
+						path: "/",
+						domain: window.location.hostname,
+						secure: config.ssl
+					});
 					cookieData = response.tokenBody;
 				}
 
@@ -188,7 +193,7 @@ domReady.then(() => {
 		if (confirm("Do you really wish to log out?")) {
 			Cookies.remove("user_data",
 				{
-					path: "",
+					path: "/",
 					domain: window.location.hostname
 				}
 			);

--- a/src/client/chat/discord-api-redirect.js
+++ b/src/client/chat/discord-api-redirect.js
@@ -1,5 +1,6 @@
 import * as Cookies from "js-cookie";
 import domReady from "../dom-ready";
+import { network as config } from "../config";
 
 domReady.then(() => {
 	let response = document.getElementById("response").dataset.response;
@@ -13,7 +14,12 @@ domReady.then(() => {
 			let user_data = JSON.parse(response);
 
 			let days = (user_data.expires_in / 62400) - 0.1; // seconds to days minus some slack
-			Cookies.set("user_data", user_data, { expires: days });
+			Cookies.set("user_data", user_data, {
+				expires: days,
+				path: "/",
+				domain: window.location.hostname,
+				secure: config.ssl
+			});
 
 			window.opener.postMessage({
 				success: true,


### PR DESCRIPTION
This has been an interesting bug to fix, since it only happened remotely. So enjoy this summary ~~that I totally didn't copy from the chat with Angelo to explain it~~:

- Cookies are stored per domain, subdomain even.
- The current domain has to match the domain it is saved with to be able to be read, but also to be removed.
- Especially when you remove a cookie, you have to specify the domain it was saved with.
- So, usually that would be `window.location.hostname`
- But in our case they got saved without specifying a domain.
- So the domain defaults to something like that, but not entirely? I don't really know, but that's why it worked locally but not remotely.


**Referencing issues**
Closes #193 