### PR TITLE
Fixes for crash and client not updating auth state

### DIFF
--- a/src/client/chat/chat.js
+++ b/src/client/chat/chat.js
@@ -1,5 +1,6 @@
 import domReady from "../dom-ready";
 import { network as config } from "../config";
+import { userState } from "../user-state";
 import * as Cookies from "js-cookie";
 import ReconnectingWebSocket from "reconnecting-websocket";
 
@@ -197,6 +198,12 @@ domReady.then(() => {
 					domain: window.location.hostname
 				}
 			);
+
+			// Send to parent if applicable
+			if (inIframe()) {
+				window.top.postMessage(userState.AUTH_CHANGED, `${window.location.origin}/client`);
+			}
+
 			window.location.reload(true);
 		}
 	}, false);
@@ -220,6 +227,11 @@ function receiveMessage(event) {
 		onAuthorization(event.data.response);
 		cookieData = Cookies.getJSON("user_data");
 		authWindow.close();
+
+		// Send to parent if applicable
+		if (inIframe()) {
+			window.top.postMessage(userState.AUTH_CHANGED, `${window.location.origin}/client`);
+		}
 	}
 }
 

--- a/src/client/chat/discord-api-redirect.js
+++ b/src/client/chat/discord-api-redirect.js
@@ -7,7 +7,7 @@ domReady.then(() => {
 
 	try {
 		let queryParameters = window.location.search.substr(1).split("&").map( el => el.split("=") );
-		if (queryParameters[0][0] === "error" && queryParameters[0][1] === "access_denied") {
+		if (queryParameters[0][0] === "error" && queryParameters[0][1] === "access_denied") { // User has cancelled the authorization, so we don't have to do anything.
 			window.close();
 		}
 		if (response) {

--- a/src/client/client/game.js
+++ b/src/client/client/game.js
@@ -1,12 +1,10 @@
 import domReady from "../dom-ready";
-import * as Cookies from "js-cookie";
 import { levelManager } from "../level-manager";
 import { marbleManager } from "../marble-manager";
+import { userState } from "../user-state";
 import { renderCore } from "../render/render-core";
 import { cameras } from "../render/cameras";
 import * as gameConstants from "../../game-constants.json";
-
-let _userData = Cookies.getJSON("user_data");
 
 let game = function() {
 	let _audio = {
@@ -254,7 +252,7 @@ let game = function() {
 						resultsEntry.removeAttribute("id");
 
 						// Highlight for current player
-						if (_userData && _userData.id === marble.userId) {
+						if (userState.data && userState.data.id === marble.userId) {
 							resultsEntry.className += " currentPlayer";
 						}
 
@@ -351,7 +349,7 @@ let game = function() {
 			listEntry.getElementsByClassName("rank")[0].innerText = "";
 			_enteredMarbleList[marble.entryId].listEntryElement = listEntry;
 
-			if (_userData && _userData.id === marble.userId) {
+			if (userState.data && userState.data.id === marble.userId) {
 				if (!renderCore.trackingCamera.target) {
 					_trackMarble(marble);
 				}

--- a/src/client/marble-manager.js
+++ b/src/client/marble-manager.js
@@ -1,9 +1,7 @@
 import * as THREE from "three";
 import * as config from "./config";
 import { renderCore } from "./render/render-core";
-import * as Cookies from "js-cookie";
-
-let _userData = Cookies.getJSON("user_data");
+import { userState } from "./user-state";
 
 // This module manages all the marbles that physically exist in the scene.
 let marbleManager = function() {
@@ -142,7 +140,7 @@ const MarbleMesh = function(marbleData) {
 
 	// Highlight own name
 	let nameSpriteOptions = {};
-	if (_userData && _userData.id === marbleData.userId) {
+	if (userState.data && userState.data.id === marbleData.userId) {
 		nameSpriteOptions.color = "#BA0069";
 		nameSpriteOptions.renderOrder = 9e9;
 	}

--- a/src/client/user-state.js
+++ b/src/client/user-state.js
@@ -1,0 +1,20 @@
+import * as Cookies from "js-cookie";
+
+window.addEventListener("message", function(event) {
+	// Don't parse anything that isn't ours
+	if (event.origin !== window.location.origin) return;
+
+	// If the authorization state has changed, update the user data
+	if (event.data === userState.AUTH_CHANGED) {
+		userState.data = Cookies.getJSON("user_data");
+		console.log("updated user_data", userState.data);
+	}
+}, false);
+
+let userState = {
+	AUTH_CHANGED: 0,
+
+	data: Cookies.getJSON("user_data")
+};
+
+export { userState };

--- a/src/client/user-state.js
+++ b/src/client/user-state.js
@@ -7,7 +7,6 @@ window.addEventListener("message", function(event) {
 	// If the authorization state has changed, update the user data
 	if (event.data === userState.AUTH_CHANGED) {
 		userState.data = Cookies.getJSON("user_data");
-		console.log("updated user_data", userState.data);
 	}
 }, false);
 

--- a/src/server/network/sockets.js
+++ b/src/server/network/sockets.js
@@ -19,13 +19,18 @@ const setupGameplay = function(db, config, game) {
 					let cookies = cookie.split("; ");
 					let user_data = cookies.find(element => { return element.startsWith("user_data"); });
 					if (user_data) {
-						user_data = decodeURIComponent(user_data);
-						user_data = user_data.substr(10);
-						user_data = JSON.parse(user_data);
-						if (db.user.idIsAuthenticated(user_data.id, user_data.access_token)) {
-							name = (` (${db.user.getUsernameById(user_data.id)})`).yellow;
-						} else {
-							name = " Hacker?!?".red;
+						try {
+							user_data = decodeURIComponent(user_data);
+							user_data = user_data.substr(10);
+							user_data = JSON.parse(user_data);
+							if (db.user.idIsAuthenticated(user_data.id, user_data.access_token)) {
+								name = (` (${db.user.getUsernameById(user_data.id)})`).yellow;
+							} else {
+								name = " Hacker?!? (Authentication failed)".red;
+							}
+						}
+						catch (error) {
+							name = " Hacker?!? (Invalid cookie)".red;
 						}
 					}
 				}


### PR DESCRIPTION
- Crash due to cookie not being the right format.
- Client authorization state is now updated on log in and log out. This allows the player's marble to be tracked automatically without refresh.

Closes #206 

This can still be improved to also update the marble sprite halfway the race, but this is good enough for now.

PS: also added a comment somewhere because I thought it could use it there c: