### PR TITLE
Marble rotation fix, minor restructures

### DIFF
--- a/src/client/client/game.js
+++ b/src/client/client/game.js
@@ -39,7 +39,7 @@ let game = function() {
 			renderCore.setCameraStyle(cameras.CAMERA_TRACKING);
 		}
 		if (renderCore.activeCamera.type === cameras.CAMERA_TRACKING) {
-			let mesh = null;
+			let target = null;
 			if (_marbleBeingTracked === marble) {
 				_marbleBeingTracked = null;
 				renderCore.setCameraStyle(cameras.CAMERA_FREE);
@@ -49,12 +49,12 @@ let game = function() {
 					_marbleBeingTracked.listEntryElement.getElementsByClassName("camera")[0].classList.remove("selected");
 				}
 				_marbleBeingTracked = marble;
-				mesh = marble.mesh;
+				target = marble.renderObject;
 				marble.listEntryElement.getElementsByClassName("camera")[0].classList.add("selected");
 			}
 
-			if (mesh !== undefined) {
-				renderCore.trackingCamera.setTarget(mesh);
+			if (target !== undefined) {
+				renderCore.trackingCamera.setTarget(target);
 			}
 		}
 	};
@@ -336,7 +336,7 @@ let game = function() {
 			_enteredMarbleList[marble.entryId] = marble;
 
 			// Add mesh
-			marbleManager.spawnMarble(marble);
+			marble.renderObject = marbleManager.spawnMarble(marble);
 
 			// Add UI stuff
 			let listEntry = _DOMElements.marbleListTemplate.cloneNode(true);

--- a/src/client/level-manager.js
+++ b/src/client/level-manager.js
@@ -262,13 +262,13 @@ function Water(parent, sunLight, waterLevel = 0, fog = false) {
 	this.waterObject.onBeforeRender = function(renderer, scene, camera) {
 		if(!renderCore.waterReflectsLevel()) parent.levelObjects.visible = false;
 		if(!renderCore.waterReflectsMarbles()) marbleManager.marbleGroup.visible = false;
-		marbleManager.marbleNamesGroup.visible = false;
+		camera.layers.disable(renderCore.SPRITE_LAYER);
 
 		originalOnBeforeRender(renderer, scene, camera);
 
 		parent.levelObjects.visible = true;
 		marbleManager.marbleGroup.visible = true;
-		marbleManager.marbleNamesGroup.visible = true;
+		camera.layers.enable(renderCore.SPRITE_LAYER);
 	};
 }
 

--- a/src/client/marble-manager.js
+++ b/src/client/marble-manager.js
@@ -7,21 +7,17 @@ let _userData = Cookies.getJSON("user_data");
 
 // This module manages all the marbles that physically exist in the scene.
 let marbleManager = function() {
-	let _marbles = [], // Array of marbles that currently exist in the scene
-		_skins = {},
+	let _skins = {},
 		_fallbackSkin = null;
 
 	return {
+		marbles: [], // Array of marbles that currently exist in the scene
 		marbleGroup: null, // Group containing marble instances
-		marbleNamesGroup: null, // Group containing name sprites
 		marbleGeometry: null,
 
 		initialize: function() {
 			this.marbleGroup = new THREE.Group();
-			this.marbleNamesGroup = new THREE.Group();
-			this.marbleNamesGroup.renderOrder = 1;
 			renderCore.mainScene.add(this.marbleGroup);
-			renderCore.mainScene.add(this.marbleNamesGroup);
 
 			// Default marble model
 			this.marbleGeometry = new THREE.SphereBufferGeometry(1, 32, 32);
@@ -47,52 +43,26 @@ let marbleManager = function() {
 
 		spawnMarble: function(marbleData) {
 			let marbleMesh = new MarbleMesh(marbleData);
-			_marbles.push(marbleMesh);
-			this.marbleGroup.add(marbleMesh.mesh);
-			this.marbleNamesGroup.add(marbleMesh.nameSprite);
-			marbleData.mesh = marbleMesh.mesh;
+			this.marbles.push(marbleMesh);
+			this.marbleGroup.add(marbleMesh.marbleOrigin);
+			return marbleMesh.marbleOrigin;
 		},
 
 		removeMarble: function(entryId) {
-			for (let marble of _marbles) {
-				if(marble.entryId === entryId) {
-					this.marbleGroup.remove(marble.mesh);
-					this.marbleNamesGroup.remove(marble.nameSprite);
+			for(let i = 0; i < this.marbles.length; i++) {
+				if(this.marbles[i].entryId === entryId) {
+					this.marbleGroup.remove(this.marbles[i].marbleOrigin);
+					this.marbles.splice(i, 1);
 					return;
 				}
 			}
 		},
 
 		clearMarbles: function() {
-			for (let marble of _marbles) {
-				this.marbleGroup.remove(marble.mesh);
-				this.marbleNamesGroup.remove(marble.nameSprite);
+			for (let marble of this.marbles) {
+				this.marbleGroup.remove(marble.marbleOrigin);
 			}
-			_marbles = [];
-		},
-
-		setMarbleTransforms: function(newPositions, newRotations) {
-			for (let i = 0; i < _marbles.length; i++) {
-				// Positions
-				_marbles[i].mesh.position.x = newPositions[i * 3 + 0];
-				_marbles[i].mesh.position.y = newPositions[i * 3 + 2];
-				_marbles[i].mesh.position.z = newPositions[i * 3 + 1];
-
-				// Rotations
-				_marbles[i].mesh.quaternion.set(
-					newRotations[i * 4 + 0],
-					newRotations[i * 4 + 1],
-					newRotations[i * 4 + 2],
-					newRotations[i * 4 + 3]
-				);
-
-				// Also update the nameSprite position
-				if (_marbles[i].nameSprite) {
-					_marbles[i].nameSprite.position.x = _marbles[i].mesh.position.x;
-					_marbles[i].nameSprite.position.y = _marbles[i].mesh.position.y + _marbles[i].size - .1;
-					_marbles[i].nameSprite.position.z = _marbles[i].mesh.position.z;
-				}
-			}
+			this.marbles = [];
 		},
 
 		getSkin: function(id) {
@@ -120,6 +90,9 @@ const MarbleMesh = function(marbleData) {
 	this.color = marbleData.color;
 	this.skinId = marbleData.skinId;
 
+	// The marble's main object, has mesh and name sprite as child objects
+	this.marbleOrigin = new THREE.Group();
+
 	this.geometry = marbleManager.marbleGeometry;
 	this.materialColor = new THREE.Color(this.color);
 	this.material = new THREE.MeshStandardMaterial({
@@ -129,6 +102,7 @@ const MarbleMesh = function(marbleData) {
 		map: marbleManager.getSkin(this.skinId)
 	});
 	this.mesh = new THREE.Mesh(this.geometry, this.material);
+	this.marbleOrigin.add(this.mesh);
 
 	// Set scale based on marble size
 	this.mesh.scale.x = this.mesh.scale.y = this.mesh.scale.z = this.size;
@@ -141,14 +115,18 @@ const MarbleMesh = function(marbleData) {
 	this.mesh.receiveShadow = config.graphics.receiveShadow.marbles;
 
 	// Highlight own name
-	let nameSpriteOptions = {};
+	let nameSpriteOptions = {
+		renderOrder: 1
+	};
 	if (_userData && _userData.id === marbleData.userId) {
 		nameSpriteOptions.color = "#BA0069";
 		nameSpriteOptions.renderOrder = 9e9;
 	}
 
-	// Add name sprite (we avoid parenting, because this will also cause it to inherit the rotation which we do not want)
+	// Add name sprite and set a height based on marble size
 	this.nameSprite = makeTextSprite(this.name, nameSpriteOptions);
+	this.nameSprite.position.y = this.size - 0.1;
+	this.marbleOrigin.add(this.nameSprite);
 };
 
 const makeTextSprite = function(message, options = {}) {
@@ -178,6 +156,8 @@ const makeTextSprite = function(message, options = {}) {
 
 	let sprite = new THREE.Sprite(spriteMaterial);
 	sprite.scale.set(0.3, 0.1, 1.0);
+	sprite.layers.disable(0);
+	sprite.layers.enable(renderCore.SPRITE_LAYER);
 	if (options.renderOrder) sprite.renderOrder = options.renderOrder;
 
 	return sprite;

--- a/src/client/marble-manager.js
+++ b/src/client/marble-manager.js
@@ -115,9 +115,7 @@ const MarbleMesh = function(marbleData) {
 	this.mesh.receiveShadow = config.graphics.receiveShadow.marbles;
 
 	// Highlight own name
-	let nameSpriteOptions = {
-		renderOrder: 1
-	};
+	let nameSpriteOptions = {};
 	if (_userData && _userData.id === marbleData.userId) {
 		nameSpriteOptions.color = "#BA0069";
 		nameSpriteOptions.renderOrder = 9e9;
@@ -158,7 +156,11 @@ const makeTextSprite = function(message, options = {}) {
 	sprite.scale.set(0.3, 0.1, 1.0);
 	sprite.layers.disable(0);
 	sprite.layers.enable(renderCore.SPRITE_LAYER);
-	if (options.renderOrder) sprite.renderOrder = options.renderOrder;
+	if (options.renderOrder !== undefined) {
+		sprite.renderOrder = options.renderOrder;
+	} else {
+		sprite.renderOrder = 1; // Defaults to 1 to resolve a render order issue with the water
+	}
 
 	return sprite;
 };

--- a/src/client/render/cameras.js
+++ b/src/client/render/cameras.js
@@ -8,6 +8,7 @@ import {
 	Euler,
 	Quaternion
 } from "three";
+import { renderCore } from "./render-core";
 
 const addRegisteredEventListener = function(scope, event, func, capture) {
 	scope.addEventListener(event, func, capture);
@@ -74,6 +75,7 @@ function FreeCamera(
 	this.pointerLockElement = options.pointerLockElement;
 	this.camera = options.camera;
 	this.camera.rotation.order = "YXZ";
+	this.camera.layers.enable(renderCore.SPRITE_LAYER);
 	this.speed = options.speed;
 
 	this.moveForward = false;
@@ -332,6 +334,7 @@ function TrackingCamera(
 	this.type = cameras.CAMERA_TRACKING;
 	this.camera = options.camera;
 	this.camera.rotation.order = "YXZ";
+	this.camera.layers.enable(renderCore.SPRITE_LAYER);
 	this.target = null;
 
 	/**

--- a/src/client/render/render-core.js
+++ b/src/client/render/render-core.js
@@ -62,6 +62,9 @@ let renderCore = function() {
 		freeCamera: null,
 		trackingCamera: null,
 
+		// Camera layer definitions
+		SPRITE_LAYER: 1,
+
 		initialize: function(defaultCameraType) {
 			// Check for WebGL availability and display a warning when it is missing.
 			if (!_isWebGLAvailable()) {

--- a/src/server/game.js
+++ b/src/server/game.js
@@ -532,23 +532,22 @@ let game = function() {
 
 			let transform = new physics.ammo.btTransform();
 			let _pos = new Float32Array(_marbles.length * 3);
-			let _rot = new Float32Array(_marbles.length * 4);
+			let _rot = new Float32Array(_marbles.length * 3);
 
 			for (let i = 0; i < _marbles.length; i++) {
 				let ms = _marbles[i].ammoBody.getMotionState();
 				if (ms) {
 					ms.getWorldTransform( transform );
 					let p = transform.getOrigin();
-					let q = transform.getRotation();
+					let r = _marbles[i].ammoBody.getAngularVelocity();
 
 					_pos[i * 3 + 0] = p.x();
-					_pos[i * 3 + 1] = p.z();
-					_pos[i * 3 + 2] = p.y();
+					_pos[i * 3 + 1] = p.y();
+					_pos[i * 3 + 2] = p.z();
 
-					_rot[i * 4 + 0] = q.x();
-					_rot[i * 4 + 1] = q.y();
-					_rot[i * 4 + 2] = q.z();
-					_rot[i * 4 + 3] = q.w();
+					_rot[i * 3 + 0] = r.x();
+					_rot[i * 3 + 1] = r.y();
+					_rot[i * 3 + 2] = r.z();
 				}
 			}
 


### PR DESCRIPTION
**Changes**
- Server now syncs angular velocity rather that quaternions (also reducing total physics data size by a some amount).
- MarbleMesh now has a "main" Three.js object with the mesh and name tag as child objects, so we can modify the mesh's rotation without the name tag spinning.
- Name tags use layers for visibility instead.
- Removed MarbleManager's `setMarbleTransforms` since it was a very specific use case. Transforms can be set directly instead.

Angular velocity isn't interpolated since the difference would hardly be noticeable (if at all), and not "correct" in either case. Maybe I'm cutting corners a little, but I'd rather not let the code do that math & array copying unless it's really worth it.

**Referencing issues**
Closes #212
