### PR TITLE
Render enhancements

### DIFF
--- a/src/client/client/game.js
+++ b/src/client/client/game.js
@@ -196,6 +196,7 @@ let game = function() {
 			switch(newState) {
 			// Start of a new round
 			case gameConstants.STATE_WAITING:
+				renderCore.autoUpdateShadowMap(false);
 				_DOMElements.gameInfo.className = "waiting";
 				clearInterval(_enterCountdownTimer);
 				_enterCountdownTimer = null;
@@ -217,6 +218,7 @@ let game = function() {
 
 			// First marble has been entered
 			case gameConstants.STATE_ENTER:
+				renderCore.autoUpdateShadowMap(true);
 				_DOMElements.gameInfo.className = "enter";
 				// Set text (set in the previous state unless this is the initial state)
 				_DOMElements.state.innerText = "Enter marbles now!";
@@ -249,6 +251,7 @@ let game = function() {
 
 			// The race has finished
 			case gameConstants.STATE_FINISHED:
+				renderCore.autoUpdateShadowMap(false);
 				_DOMElements.gameInfo.className = "finished";
 				if (_serverData.currentGameState !== null) {
 					_audio.end.play();

--- a/src/client/client/game.js
+++ b/src/client/client/game.js
@@ -218,7 +218,6 @@ let game = function() {
 
 			// First marble has been entered
 			case gameConstants.STATE_ENTER:
-				renderCore.autoUpdateShadowMap(true);
 				_DOMElements.gameInfo.className = "enter";
 				// Set text (set in the previous state unless this is the initial state)
 				_DOMElements.state.innerText = "Enter marbles now!";
@@ -398,6 +397,9 @@ let game = function() {
 
 			_DOMElements.marbleList.appendChild(listEntry);
 			_DOMElements.entries.innerHTML = _enteredMarbleList.length;
+
+			// Make sure shadows updates are enabled
+			renderCore.autoUpdateShadowMap(true);
 		},
 
 		finishMarble: function(marble) {

--- a/src/client/level-manager.js
+++ b/src/client/level-manager.js
@@ -391,6 +391,7 @@ Sky.prototype.recalculate = function(parameters) {
 	this.skyObject.material.uniforms.sunPosition.value = this.sunLight.position.copy(this.sunLight.position);
 	this.sunLight.shadow.mapSize.width = 2048; // default
 	this.sunLight.shadow.mapSize.height = 2048; // default
+	this.sunLight.shadow.bias = -0.00005;
 	this.sunLight.shadow.camera.near = 3500;
 	this.sunLight.shadow.camera.far = 4200;
 	this.sunLight.shadow.camera.left = -69;

--- a/src/client/level-manager.js
+++ b/src/client/level-manager.js
@@ -3,12 +3,14 @@ import {
 	AmbientLight,
 	TextureLoader,
 	RepeatWrapping as THREE_REPEAT_WRAPPING,
+	RGBADepthPacking as THREE_RGBA_DEPTH_PACKING,
 	Vector3,
 	Quaternion,
 	Group,
 	PlaneBufferGeometry,
 	DirectionalLight,
-	CameraHelper
+	CameraHelper,
+	MeshDepthMaterial
 } from "three";
 import { Water as ThreeWater } from "three/examples/jsm/objects/Water";
 import { Sky as ThreeSky } from "three/examples/jsm/objects/Sky";
@@ -33,7 +35,7 @@ function MarbleLevel() { // "Map" is taken. This comment is left here in memory 
 	this.startingGates = [];
 
 	// Ambient light
-	let ambientLight = new AmbientLight(0x746070);
+	let ambientLight = new AmbientLight(0x746070, 1);
 	this.scene.add(ambientLight);
 
 	// Sky + Sunlight
@@ -262,6 +264,17 @@ MarbleLevel.prototype.loadLevel = function(data) {
 			let clone = prefabs[object.prefab].clone();
 			clone.position.copy(new Vector3(object.position.x, object.position.y, object.position.z));
 			clone.setRotationFromQuaternion(new Quaternion(object.rotation.x, object.rotation.y, object.rotation.z, object.rotation.w));
+			clone.traverse((obj) => {
+				if (obj.material && obj.material.map) {
+					obj.customDepthMaterial = new MeshDepthMaterial({
+						map: obj.material.map,
+						depthPacking: THREE_RGBA_DEPTH_PACKING,
+						alphaTest: .5
+					});
+					obj.castShadow = true;
+					obj.receiveShadow = true;
+				}
+			});
 			this.levelObjects.add(clone);
 
 			// Keep starting gate prefabObjects in a separate array for opening/closing
@@ -271,11 +284,16 @@ MarbleLevel.prototype.loadLevel = function(data) {
 				}
 			}
 		}
+
 		// Disable matrix updates
 		this.levelObjects.traverse( (obj) => {
 			obj.updateMatrix();
 			obj.matrixAutoUpdate = false;
 		});
+
+		// Update shadow map
+		renderCore.updateShadowMap();
+
 		return warnings;
 	});
 };
@@ -336,7 +354,7 @@ function Sky(parameters = {}) {
 	this.group.add(this.skyObject);
 
 	// Light
-	let sunLight = this.sunLight = new DirectionalLight(0xf5d0d0, 1.5);
+	let sunLight = this.sunLight = new DirectionalLight(0xf5d0d0, 2.5);
 	sunLight.castShadow = true;
 
 	this.group.add(sunLight);
@@ -377,7 +395,7 @@ Sky.prototype.recalculate = function(parameters) {
 	this.sunLight.shadow.camera.far = 4200;
 	this.sunLight.shadow.camera.left = -69;
 	this.sunLight.shadow.camera.right = 60;
-	this.sunLight.shadow.camera.top = 50;
+	this.sunLight.shadow.camera.top = 60;
 	this.sunLight.shadow.camera.bottom = -30;
 
 	if (this.water) {

--- a/src/client/render/render-core.js
+++ b/src/client/render/render-core.js
@@ -226,7 +226,6 @@ let renderCore = function() {
 
 		autoUpdateShadowMap: function(autoUpdate = true) {
 			_renderer.shadowMap.autoUpdate = autoUpdate;
-			this.updateShadowMap();
 		},
 
 		waterReflectsLevel: function() {

--- a/src/client/render/render-core.js
+++ b/src/client/render/render-core.js
@@ -4,7 +4,7 @@ import {
 	Mesh,
 	BoxBufferGeometry,
 	MeshStandardMaterial,
-	PCFSoftShadowMap as THREE_PCF_SOFT_SHADOW_MAP
+	PCFShadowMap as THREE_PCF_SHADOW_MAP
 } from "three";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
 import * as config from "../config";
@@ -131,7 +131,7 @@ let renderCore = function() {
 
 				// Renderer defaults
 				_renderer.shadowMap.enabled = true;
-				_renderer.shadowMap.type = THREE_PCF_SOFT_SHADOW_MAP; // default is THREE.PCFShadowMap
+				_renderer.shadowMap.type = THREE_PCF_SHADOW_MAP; // default is THREE.PCFShadowMap
 
 				// Stats
 				_stats = new Stats();

--- a/src/client/render/render-core.js
+++ b/src/client/render/render-core.js
@@ -95,6 +95,9 @@ let renderCore = function() {
 			} else { // Initialize
 				this.mainScene = new Scene();
 				_renderer = new WebGLRenderer();
+				_renderer.gammaInput = true;
+				_renderer.gammaOutput = true;
+				_renderer.gammaFactor = 2.2;
 				_renderer.debug.checkShaderErrors = false;
 				_defaultModel = new Mesh(
 					new BoxBufferGeometry(1, 1, 1, 1),
@@ -215,6 +218,15 @@ let renderCore = function() {
 
 		updateCallback: function() {
 			// Overridable function for the client and editor to attach their update functions to.
+		},
+
+		updateShadowMap: function() {
+			_renderer.shadowMap.needsUpdate = true;
+		},
+
+		autoUpdateShadowMap: function(autoUpdate = true) {
+			_renderer.shadowMap.autoUpdate = autoUpdate;
+			this.updateShadowMap();
 		},
 
 		waterReflectsLevel: function() {


### PR DESCRIPTION
Some tweaks to make the level look much nicer. Performance should be about equal with the previous version.
- Gamma is adjusted to look less harsh
- Shadows on level objects take textures with partial transparency into account
- Shadows only update when marbles are rolling

There's a known issue that shadows cast by marbles do not show until a human marble is entered, but since this is an rare situation, I decided to let it slip.

Will probably merge this myself after a day or two if there are no objections by then.
