### PR TITLE
Various rendering fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "request-promise-native": "^1.0.7",
     "semver": "^7.1.0",
     "stats-js": "^1.0.0",
-    "three": "^0.115.0",
+    "three": "^0.114.0",
     "uWebSockets.js": "uNetworking/uWebSockets.js#v17.3.0"
   },
   "optionalDependencies": {

--- a/public/resources/skins/galaxy/meta.json
+++ b/public/resources/skins/galaxy/meta.json
@@ -5,6 +5,6 @@
 		"galaxy"
 	],
 	"allowCustomColor": false,
-	"roughness": 0.9,
-	"metalness": 0.2
+	"roughness": 0.2,
+	"metalness": 0.5
 }

--- a/src/client/client/game.js
+++ b/src/client/client/game.js
@@ -197,6 +197,7 @@ let game = function() {
 			// Start of a new round
 			case gameConstants.STATE_WAITING:
 				renderCore.autoUpdateShadowMap(false);
+				renderCore.updateShadowMap(); // Update the shadows once for when last round's marbles disappear
 				_DOMElements.gameInfo.className = "waiting";
 				clearInterval(_enterCountdownTimer);
 				_enterCountdownTimer = null;

--- a/src/client/client/game.js
+++ b/src/client/client/game.js
@@ -255,7 +255,6 @@ let game = function() {
 				_DOMElements.gameInfo.className = "finished";
 				if (_serverData.currentGameState !== null) {
 					_audio.end.play();
-					levelManager.activeLevel.closeGates();
 
 					_enteredMarbleList.sort((a, b) => {
 						if (a.finished && b.finished) {

--- a/src/client/level-manager.js
+++ b/src/client/level-manager.js
@@ -322,6 +322,12 @@ function Water(parent, sunLight, waterLevel = 0, fog = false) {
 	this.waterObject.rotation.x = -Math.PI / 2;
 	this.waterObject.position.y = waterLevel;
 	this.waterObject.material.uniforms.size.value = 8;
+
+	// Sets the water's render target output to the same encoding type as the renderer's, fixing the shader recompile issue
+	// NOTE: What we mean to modify here is renderTarget.texture, which we don't have access to
+	// But luckily we can get to the texture through the material's uniforms :D
+	this.waterObject.material.uniforms[ "mirrorSampler" ].value.encoding = THREE_CONSTANTS.GammaEncoding;
+
 	let originalOnBeforeRender = this.waterObject.onBeforeRender;
 	this.waterObject.onBeforeRender = function(renderer, scene, camera) {
 		if(!renderCore.waterReflectsLevel()) parent.levelObjects.visible = false;

--- a/src/client/skins/skins.js
+++ b/src/client/skins/skins.js
@@ -39,14 +39,12 @@ let _marbleRight = marbleManager.spawnMarble(_marbleData);
 _marbleLeft.position.x = renderCore.activeCamera.camera.position.x - 1.3;
 _marbleLeft.position.y = renderCore.activeCamera.camera.position.y - 1;
 _marbleLeft.position.z = renderCore.activeCamera.camera.position.z - 3;
-renderCore.mainScene.add(_marbleLeft);
 
 // Right mesh
 _marbleRight.position.x = renderCore.activeCamera.camera.position.x + 1.3;
 _marbleRight.position.y = renderCore.activeCamera.camera.position.y - 1;
 _marbleRight.position.z = renderCore.activeCamera.camera.position.z - 3;
 _marbleRight.rotation.y = Math.PI;
-renderCore.mainScene.add(_marbleRight);
 
 domReady.then(() => {
 	for (let skinEntry of document.getElementsByClassName("skinEntry")) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4440,10 +4440,10 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three@^0.115.0:
-  version "0.115.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.115.0.tgz#540d800c381b9da2334c024f0fbe4d23f84eb05e"
-  integrity sha512-mAV2Ky3RdcbdSbR9capI+tKLvRldWYxd4151PZTT/o7+U2jh9Is3a4KmnYwzyUAhB2ZA3pXSgCd2DOY4Tj5kow==
+three@^0.114.0:
+  version "0.114.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.114.0.tgz#754d08467a950ddeef06a0c645a1302b130e455a"
+  integrity sha512-3av45FxJeqYm7Rl02dfGBoqTaf2a934oUB4zMNrN8xjmASoSGeeykYoAr35+UntTdJDY/STw6CY3KuXFBWETig==
 
 through2@^2.0.0:
   version "2.0.5"


### PR DESCRIPTION
A number of rendering bugs that got piled up that are now fixed!
- Fixed a case where shaders kept getting recompiled due to encoding differences by the water reflection's and main renderer output.
- Reverted to Three.js r114 due to a water rendering bug (render target isn't cleared correctly).
- Fixed the issue where marbles on the `skins` page had a reflection when they shouldn't have one.
- Fixed the issue where shadows weren't updated at the end of a finished race.

The gate had the same shadow issue after the current fix, and since it's prooobably clearer if it spawned in at the start of the enter period (instead of right when the race finishes), I decided to change that behaviour slightly. Lemme know if that's a no-go though!

Note is that the Three.js water bug is fixed in development, but not in the latest release. It's probably better to wait till April 29th when r116 is supposed to be available.

**Referencing issues**
Closes #198 
Closes #269 
Closes #276 
