### PR TITLE
Bugfix: Inactive tab / network buffer issue

### DIFF
--- a/src/client/client/client.js
+++ b/src/client/client/client.js
@@ -11,10 +11,3 @@ renderCore.initialize(cameras.CAMERA_TRACKING);
 levelManager.initialize();
 marbleManager.initialize();
 game.initialize();
-
-function clientUpdate(deltaTime) {
-	levelManager.activeLevel.update(deltaTime);
-	networking.update(deltaTime);
-}
-
-renderCore.updateCallback = clientUpdate;

--- a/src/client/client/game.js
+++ b/src/client/client/game.js
@@ -5,6 +5,8 @@ import { userState } from "../user-state";
 import { renderCore } from "../render/render-core";
 import { cameras } from "../render/cameras";
 import { HUDNotification } from "./hud-notification";
+import { updateManager } from "../update-manager";
+import { networking } from "./networking";
 import * as gameConstants from "../../game-constants.json";
 
 let game = function() {
@@ -92,6 +94,11 @@ let game = function() {
 		}
 	};
 
+	let _update = function(deltaTime) {
+		levelManager.activeLevel.update(deltaTime);
+		networking.update(deltaTime);
+	};
+
 	return {
 		// Returns a Promise that resolves once initialization is complete
 		// Can be called multiple times but will initialize only once
@@ -110,6 +117,7 @@ let game = function() {
 					_DOMElements.raceLeaderboardAuthorName = _DOMElements.raceLeaderboard.getElementsByClassName("authorName")[0];
 					_DOMElements.resultsList = document.getElementById("resultsList");
 					_DOMElements.resultsListTemplate = document.getElementById("resultsListTemplate");
+					updateManager.addUpdateCallback(_update);
 				});
 			}
 			return _initPromise;

--- a/src/client/client/game.js
+++ b/src/client/client/game.js
@@ -9,8 +9,8 @@ import { updateManager } from "../update-manager";
 import { networking } from "./networking";
 import * as gameConstants from "../../game-constants.json";
 
-let game = function() {
-	let _audio = {
+const game = function() {
+	const _audio = {
 		start: new Audio("resources/audio/start.mp3"),
 		end: new Audio("resources/audio/end.mp3")
 	};
@@ -35,7 +35,7 @@ let game = function() {
 
 		_marbleBeingTracked = null;
 
-	let _trackMarble = function(marble, forceTracking) {
+	const _trackMarble = function(marble, forceTracking) {
 		if (forceTracking) {
 			renderCore.setCameraStyle(cameras.CAMERA_TRACKING);
 		}
@@ -61,7 +61,7 @@ let game = function() {
 	};
 
 	// Starts the "enter marbles now" visual timer. timeLeft in milliseconds
-	let _startEnterCountdown = function(timerValue) {
+	const _startEnterCountdown = function(timerValue) {
 		// Make sure it only runs once
 		if(_enterCountdownTimer !== null) clearInterval(_enterCountdownTimer);
 
@@ -87,14 +87,14 @@ let game = function() {
 		}, timerValue % 1000); // milliseconds only, i.e. 23941 becomes 941
 	};
 
-	let _animateRoundTimer = function() {
+	const _animateRoundTimer = function() {
 		if (_roundTimerIsVisible) {
 			requestAnimationFrame(_animateRoundTimer);
 			_DOMElements.timer.innerText = ((Date.now() - _roundTimerStartDate) * .001).toFixed(1);
 		}
 	};
 
-	let _update = function(deltaTime) {
+	const _update = function(deltaTime) {
 		levelManager.activeLevel.update(deltaTime);
 		networking.update(deltaTime);
 	};

--- a/src/client/client/networking.js
+++ b/src/client/client/networking.js
@@ -18,21 +18,10 @@ const networking = function() {
 	let _previousMarblePositions = null;
 
 	// Page visibility logic. If the page is hidden, the network buffer will fast-forward when a race ends
-	// Based on https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API example code
+	// https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState
 	let isPageHidden = false;
-	let hiddenVarName, visibilityChangeEventName;
-	if(typeof document.hidden !== "undefined") {
-		hiddenVarName = "hidden";
-		visibilityChangeEventName = "visibilitychange";
-	} else if(typeof document.msHidden !== "undefined") {
-		hiddenVarName = "msHidden";
-		visibilityChangeEventName = "msvisibilitychange";
-	} else if(typeof document.webkitHidden !== "undefined") {
-		hiddenVarName = "webkitHidden";
-		visibilityChangeEventName = "webkitvisibilitychange";
-	}
-
-	document.addEventListener(visibilityChangeEventName, () => {isPageHidden = document[hiddenVarName];}, false);
+	document.addEventListener("visibilitychange", () => {isPageHidden = document.visibilityState === "hidden";}, false);
+	window.addEventListener("pagehide", () => {isPageHidden = document.visibilityState === "hidden";}, false); // Safari fix, which doesn't trigger the visibilitychange event
 
 	const _processMessageEvent = function(event) {
 		if(typeof event.data === "string") {

--- a/src/client/client/networking.js
+++ b/src/client/client/networking.js
@@ -6,6 +6,7 @@ import * as gameConstants from "../../game-constants.json";
 import { marbleManager } from "../marble-manager";
 import { Vector3 } from "three";
 import * as msgPack from "msgpack-lite";
+import { updateManager } from "../update-manager";
 
 let networking = function() {
 	let _wsUri = `ws${config.ssl ? "s" : ""}://${window.location.hostname}${config.websockets.localReroute ? "" : `:${config.websockets.port}`}/ws/gameplay`;
@@ -31,8 +32,10 @@ let networking = function() {
 			let contents = msgPack.decode(new Uint8Array(event.data));
 			_updateBuffer.push(contents);
 
+			// Trigger normal progression
+			updateManager.triggerUpdate();
+
 			// Force progression if buffer gets too large
-			// This may happen frequently with inactive tabs
 			while(_updateBuffer.length > config.maxBufferSize) {
 				_processGameEvents(_updateBuffer[0]);
 				_updateBuffer.splice(0, 1);

--- a/src/client/client/networking.js
+++ b/src/client/client/networking.js
@@ -8,8 +8,8 @@ import { Vector3 } from "three";
 import * as msgPack from "msgpack-lite";
 import { updateManager } from "../update-manager";
 
-let networking = function() {
-	let _wsUri = `ws${config.ssl ? "s" : ""}://${window.location.hostname}${config.websockets.localReroute ? "" : `:${config.websockets.port}`}/ws/gameplay`;
+const networking = function() {
+	const _wsUri = `ws${config.ssl ? "s" : ""}://${window.location.hostname}${config.websockets.localReroute ? "" : `:${config.websockets.port}`}/ws/gameplay`;
 	let _ws = null;
 
 	let _updateBuffer = []; // Array of game updates, each containing events and marble data
@@ -17,7 +17,24 @@ let networking = function() {
 	let _desiredBufferSize = config.defaultBufferSize; // Desired buffer size
 	let _previousMarblePositions = null;
 
-	let _processMessageEvent = function(event) {
+	// Page visibility logic. If the page is hidden, the network buffer will fast-forward when a race ends
+	// Based on https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API example code
+	let isPageHidden = false;
+	let hiddenVarName, visibilityChangeEventName;
+	if(typeof document.hidden !== "undefined") {
+		hiddenVarName = "hidden";
+		visibilityChangeEventName = "visibilitychange";
+	} else if(typeof document.msHidden !== "undefined") {
+		hiddenVarName = "msHidden";
+		visibilityChangeEventName = "msvisibilitychange";
+	} else if(typeof document.webkitHidden !== "undefined") {
+		hiddenVarName = "webkitHidden";
+		visibilityChangeEventName = "webkitvisibilitychange";
+	}
+
+	document.addEventListener(visibilityChangeEventName, () => {isPageHidden = document[hiddenVarName];}, false);
+
+	const _processMessageEvent = function(event) {
 		if(typeof event.data === "string") {
 			// This should only be a HUD Notification
 			let message = JSON.parse(event.data);
@@ -35,6 +52,15 @@ let networking = function() {
 			// Trigger normal progression
 			updateManager.triggerUpdate();
 
+			// Fast-forward when the page is inactive and the race has ended
+			if(isPageHidden && contents.g === gameConstants.STATE_FINISHED) {
+				while(_updateBuffer.length > 0) {
+					_processGameEvents(_updateBuffer[0]);
+					_updateBuffer.splice(0, 1);
+					if(_timeDeltaRemainder !== null) _timeDeltaRemainder = 0;
+				}
+			}
+
 			// Force progression if buffer gets too large
 			while(_updateBuffer.length > config.maxBufferSize) {
 				_processGameEvents(_updateBuffer[0]);
@@ -45,7 +71,7 @@ let networking = function() {
 		}
 	};
 
-	let _processGameEvents = function(thisUpdate) {
+	const _processGameEvents = function(thisUpdate) {
 		// Update server constants
 		if(thisUpdate.s !== undefined) {
 			game.setServerConstants(thisUpdate.s[0], thisUpdate.s[1]);

--- a/src/client/editor/editor.js
+++ b/src/client/editor/editor.js
@@ -110,10 +110,10 @@ EditorObject.prototype.setName = function(name) {
 };
 
 
-let editor = function() {
+const editor = function() {
 	let _activeTab = 2;
 
-	let _update = function(deltaTime) {
+	const _update = function(deltaTime) {
 		levelManager.activeLevel.update(deltaTime);
 	};
 

--- a/src/client/editor/editor.js
+++ b/src/client/editor/editor.js
@@ -18,6 +18,7 @@ import { renderCore } from "../render/render-core";
 import { cameras } from "../render/cameras";
 import { levelManager } from "../level-manager";
 import { marbleManager } from "../marble-manager";
+import { updateManager } from "../update-manager";
 
 
 // Object template used by prefabObject, prefabCollider, and worldObject
@@ -112,6 +113,10 @@ EditorObject.prototype.setName = function(name) {
 let editor = function() {
 	let _activeTab = 2;
 
+	let _update = function(deltaTime) {
+		levelManager.activeLevel.update(deltaTime);
+	};
+
 	return {
 		elements: {
 			inspector: null
@@ -133,7 +138,7 @@ let editor = function() {
 			prefabsTab.initialize();
 			worldTab.initialize();
 
-			renderCore.updateCallback = this.update;
+			updateManager.addUpdateCallback(_update);
 
 			// Update version number
 			document.getElementById("editorVersion").innerHTML = `v${levelIO.getCurrentVersion()}`;
@@ -233,10 +238,6 @@ let editor = function() {
 			// Models tab is the active tab on load
 			document.getElementById("properties").firstElementChild.style.marginLeft = "-200%";
 			modelsTab.onTabActive();
-		},
-
-		update: function(deltaTime) {
-			levelManager.activeLevel.update(deltaTime);
 		}
 	};
 }();

--- a/src/client/render/cameras.js
+++ b/src/client/render/cameras.js
@@ -507,7 +507,7 @@ const _lookAtWithReturn = function() {
 		if (parent) {
 			m1.extractRotation(parent.matrixWorld);
 			q1.setFromRotationMatrix(m1);
-			return q2.premultiply(q1.inverse());
+			return q2.premultiply(q1.invert());
 		}
 	};
 }();

--- a/src/client/skins/skins.js
+++ b/src/client/skins/skins.js
@@ -3,11 +3,12 @@ import { levelManager } from "../level-manager";
 import { marbleManager } from "../marble-manager";
 import { marbleSkins } from "../marble-skins";
 import { cameras } from "../render/cameras";
+import { updateManager } from "../update-manager";
 import domReady from "../dom-ready";
 
 // Set up core (rendering, level & marble management)
 renderCore.initialize(cameras.CAMERA_FREE);
-renderCore.updateCallback = function(deltaTime) {
+let update = function(deltaTime) {
 	levelManager.activeLevel.update(deltaTime);
 
 	if (_rotateMarbles) {
@@ -75,4 +76,5 @@ domReady.then(() => {
 	document.getElementById("toggleRotate").addEventListener("change", function() {
 		_rotateMarbles = this.checked;
 	}, false);
+	updateManager.addUpdateCallback(update);
 });

--- a/src/client/skins/skins.js
+++ b/src/client/skins/skins.js
@@ -8,7 +8,7 @@ import domReady from "../dom-ready";
 
 // Set up core (rendering, level & marble management)
 renderCore.initialize(cameras.CAMERA_FREE);
-let update = function(deltaTime) {
+const update = function(deltaTime) {
 	levelManager.activeLevel.update(deltaTime);
 
 	if (_rotateMarbles) {

--- a/src/client/update-manager.js
+++ b/src/client/update-manager.js
@@ -1,6 +1,6 @@
 import domReady from "./dom-ready";
 
-let updateManager = function() {
+const updateManager = function() {
 	let _previousTime = Date.now();
 	let _updateFunctions = [];
 

--- a/src/client/update-manager.js
+++ b/src/client/update-manager.js
@@ -1,0 +1,29 @@
+import domReady from "./dom-ready";
+
+let updateManager = function() {
+	let _previousTime = Date.now();
+	let _updateFunctions = [];
+
+	domReady.then(() => {
+		_previousTime = Date.now(); // Update loop starts from this point in time, ignore load time
+	});
+
+	return {
+		addUpdateCallback: function(func) {
+			_updateFunctions.push(func);
+		},
+
+		triggerUpdate: function() {
+			let now = Date.now();
+			let deltaTime = (now - _previousTime) * 0.001; // Time in seconds
+			_previousTime = now;
+
+			for(let i = 0; i < _updateFunctions.length; i++) {
+				_updateFunctions[i](deltaTime);
+			}
+			return deltaTime;
+		}
+	};
+}();
+
+export { updateManager };


### PR DESCRIPTION
Fixes the increasing network delay issue when the client page is an inactive tab for a while.

Previously, game/network updates were triggered by the rendering only. This generally worked fine, except that the rendering loop slows significantly when the tab isn't active, causing the network to still receive data while the update functions weren't called. This pull request adds a simple `updateManager` module to create a more centralized way of adding update functions to a list and allows any other module to trigger an update (instead of completely leaving it the renderer's responsibility).

Because the network packets stop right after the end of a race (as there's no new data to send at that time), there *is* a tiny bit of network buffer left at the end of a race that doesn't get processed immediately if the tab stays inactive. This would still cause a "delay", unless the client switches back to the tab again at some point or once the game state changes from `finished` to `waiting`. I'd consider this only a small issue, and given how the solution to that would involve creating a worker thread to periodically force updates I don't it's worth addressing.

**Referencing issues**
Closes #232
